### PR TITLE
feat: add custom ease composables

### DIFF
--- a/README.md
+++ b/README.md
@@ -821,6 +821,34 @@ Specifies GSAP extra eases.
 const { $ExpoScaleEase } = useNuxtApp()
 ```
 
+### useExpoScaleEase
+
+- Custom composable
+
+```ts
+// nuxt.config.ts
+
+{
+  gsap: {
+    composables: true,
+    extraEases: {
+      expoScale: true
+    }
+  }
+}
+```
+
+**Usage**
+
+```ts
+useExpoScaleEase
+```
+
+```ts
+// Explicit import (optional)
+import { useExpoScaleEase } from '#gsap'
+```
+
 ### Rough
 
 - Type: `boolean`
@@ -842,6 +870,34 @@ const { $ExpoScaleEase } = useNuxtApp()
 
 ```ts
 const { $RoughEase } = useNuxtApp()
+```
+
+### useRoughEase
+
+- Custom composable
+
+```ts
+// nuxt.config.ts
+
+{
+  gsap: {
+    composables: true,
+    extraEases: {
+      rough: true
+    }
+  }
+}
+```
+
+**Usage**
+
+```ts
+useRoughEase
+```
+
+```ts
+// Explicit import (optional)
+import { useRoughEase } from '#gsap'
 ```
 
 ### SlowMo
@@ -867,6 +923,34 @@ const { $RoughEase } = useNuxtApp()
 const { $SlowMo } = useNuxtApp()
 ```
 
+### useSlowMo
+
+- Custom composable
+
+```ts
+// nuxt.config.ts
+
+{
+  gsap: {
+    composables: true,
+    extraEases: {
+      slowMo: true
+    }
+  }
+}
+```
+
+**Usage**
+
+```ts
+useSlowMo
+```
+
+```ts
+// Explicit import (optional)
+import { useSlowMo } from '#gsap'
+```
+
 ### Custom
 
 - Type: `boolean`
@@ -888,6 +972,34 @@ const { $SlowMo } = useNuxtApp()
 
 ```ts
 const { $CustomEase } = useNuxtApp()
+```
+
+### useCustomEase
+
+- Custom composable
+
+```ts
+// nuxt.config.ts
+
+{
+  gsap: {
+    composables: true,
+    extraEases: {
+      custom: true
+    }
+  }
+}
+```
+
+**Usage**
+
+```ts
+useCustomEase
+```
+
+```ts
+// Explicit import (optional)
+import { useCustomEase } from '#gsap'
 ```
 
 ## Club Plugins

--- a/src/module.ts
+++ b/src/module.ts
@@ -65,13 +65,13 @@ export default defineNuxtModule<ModuleOptions>({
 
       const addPlugin = ({
         name,
-        pkgName,
+        subpath,
       }: {
         name: string
-        pkgName?: string
+        subpath?: string
       }) => {
         pluginImport.push(
-          `import { ${name} } from 'gsap/${pkgName ? pkgName : name}';`,
+          `import { ${name} } from 'gsap/${subpath ? subpath : name}';`,
         )
         pluginRegister.push(`${name}`)
         pluginType.push(`${name}: typeof ${name};`)
@@ -90,9 +90,9 @@ export default defineNuxtModule<ModuleOptions>({
 
       // Extra Eases
       if (eases?.expoScale)
-        addPlugin({ name: 'ExpoScaleEase', pkgName: 'EasePack' })
-      if (eases?.rough) addPlugin({ name: 'RoughEase', pkgName: 'EasePack' })
-      if (eases?.slowMo) addPlugin({ name: 'SlowMo', pkgName: 'EasePack' })
+        addPlugin({ name: 'ExpoScaleEase', subpath: 'EasePack' })
+      if (eases?.rough) addPlugin({ name: 'RoughEase', subpath: 'EasePack' })
+      if (eases?.slowMo) addPlugin({ name: 'SlowMo', subpath: 'EasePack' })
       if (eases?.custom) addPlugin({ name: 'CustomEase' })
 
       // Club Plugins
@@ -173,13 +173,13 @@ export default defineNuxtModule<ModuleOptions>({
 
       const addComposable = ({
         name,
-        pkgName,
+        subpath,
       }: {
         name: string
-        pkgName?: string
+        subpath?: string
       }) => {
         pluginImport.push(
-          `import { ${name} } from 'gsap/${pkgName ? pkgName : name}';`,
+          `import { ${name} } from 'gsap/${subpath ? subpath : name}';`,
         )
         pluginRegister.push(`${name}`)
         pluginDeclare.push(`export const use${name} = ${name};`)
@@ -228,6 +228,24 @@ export default defineNuxtModule<ModuleOptions>({
       if (plugins?.text) {
         addComposable({ name: 'TextPlugin' })
         if (autoImport) addImports({ name: 'useTextPlugin', from: alias })
+      }
+
+      // Extra Eases
+      if (eases?.expoScale) {
+        addComposable({ name: 'ExpoScaleEase', subpath: 'EasePack' })
+        if (autoImport) addImports({ name: 'useExpoScaleEase', from: alias })
+      }
+      if (eases?.rough) {
+        addComposable({ name: 'RoughEase', subpath: 'EasePack' })
+        if (autoImport) addImports({ name: 'useRoughEase', from: alias })
+      }
+      if (eases?.slowMo) {
+        addComposable({ name: 'SlowMo', subpath: 'EasePack' })
+        if (autoImport) addImports({ name: 'useSlowMo', from: alias })
+      }
+      if (eases?.custom) {
+        addComposable({ name: 'CustomEase' })
+        if (autoImport) addImports({ name: 'useCustomEase', from: alias })
       }
 
       addTemplate({


### PR DESCRIPTION

## Type of Change

- [x] New feature
- [x] Documentation


## Request Description

Adds custom ease composables.


### useExpoScaleEase

- Custom composable

```ts
// nuxt.config.ts

{
  gsap: {
    composables: true,
    extraEases: {
      expoScale: true
    }
  }
}
```

**Usage**

```ts
useExpoScaleEase
```

```ts
// Explicit import (optional)
import { useExpoScaleEase } from '#gsap'
```

### useRoughEase

- Custom composable

```ts
// nuxt.config.ts

{
  gsap: {
    composables: true,
    extraEases: {
      rough: true
    }
  }
}
```

**Usage**

```ts
useRoughEase
```

```ts
// Explicit import (optional)
import { useRoughEase } from '#gsap'
```

### useSlowMo

- Custom composable

```ts
// nuxt.config.ts

{
  gsap: {
    composables: true,
    extraEases: {
      slowMo: true
    }
  }
}
```

**Usage**

```ts
useSlowMo
```

```ts
// Explicit import (optional)
import { useSlowMo } from '#gsap'
```

### useCustomEase

- Custom composable

```ts
// nuxt.config.ts

{
  gsap: {
    composables: true,
    extraEases: {
      custom: true
    }
  }
}
```

**Usage**

```ts
useCustomEase
```

```ts
// Explicit import (optional)
import { useCustomEase } from '#gsap'
```